### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a [Mutagen](https://github.com/Mutagen-Modding/Mutagen)-based autopatche
 
 # Description
 
-Makes items weightless by type. 
+Makes Fallout 4 Items weightless by type. 
 
 Types are: Misc Items, Ammo, Holotapes, Keys, Notes, Ingestibles, Weapons, Armor&Clothing
 Be aware that for the last two categories this only affects the base weight. Modifications might still increase it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a [Mutagen](https://github.com/Mutagen-Modding/Mutagen)-based autopatche
 
 # Description
 
-Makes Fallout 4 Items weightless by type. 
+Makes Fallout 4 items weightless by type. 
 
 Types are: Misc Items, Ammo, Holotapes, Keys, Notes, Ingestibles, Weapons, Armor&Clothing
 Be aware that for the last two categories this only affects the base weight. Modifications might still increase it.


### PR DESCRIPTION
Add Fallout 4 mention to the description section as the text before it isn't shown consistently in Synthesis